### PR TITLE
Allow building on FreeBSD

### DIFF
--- a/appinst.cpp
+++ b/appinst.cpp
@@ -21,6 +21,8 @@
  */
  
 
+#include <sys/stat.h>
+
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>

--- a/icd-main.cpp
+++ b/icd-main.cpp
@@ -19,7 +19,7 @@
 
 #include <map>
 #include <signal.h>
-#include <wait.h>
+#include <sys/wait.h>
 #include <fcntl.h>
 #include <pwd.h>
 #include <dirent.h>

--- a/ict-main.cpp
+++ b/ict-main.cpp
@@ -19,13 +19,12 @@
  */
 
 
-#include <argp.h>
+#include <errno.h>
 #include <pwd.h>
 #include <string>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
-#include <sys/inotify.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <limits.h>
@@ -504,7 +503,7 @@ int main(int argc, char** argv)
       if (uid != 0) {
         fprintf(stderr, "insufficient privileges to use custom configuration (will use default)\n");
       }
-      else if (euidaccess(cfg.c_str(), R_OK) != 0) {
+      else if (eaccess(cfg.c_str(), R_OK) != 0) {
         perror("cannot read configuration file (will use default)");
       }
     }

--- a/inotify-cxx.h
+++ b/inotify-cxx.h
@@ -247,11 +247,7 @@ public:
     if (pEvt != NULL) {
       m_uMask = (uint32_t) pEvt->mask;
       m_uCookie = (uint32_t) pEvt->cookie;
-      if (pEvt->name != NULL) {
-        m_name = pEvt->len > 0
-            ? pEvt->name
-            : "";
-      }
+      m_name = pEvt->len > 0 ? pEvt->name : "";
       m_pWatch = pWatch;
     }
     else {

--- a/usertable.cpp
+++ b/usertable.cpp
@@ -573,6 +573,17 @@ bool UserTable::MayAccess(const std::string& rPath, bool fNoFollow) const
   return false; // no access right found
 }
 
+#ifndef __linux__
+static int
+clearenv(void)
+{
+  extern char **environ;
+
+  environ[0] = NULL;
+  return 0;
+}
+#endif
+
 void UserTable::RunAsUser(std::string cmd) const
 {
   struct passwd* pwd = getpwnam(m_user.c_str());


### PR DESCRIPTION
Using the libinotify-kqueue [port](http://www.freshports.org/devel/libinotify) by @sunpoet, I was able to port `incron` to FreeBSD with relative ease.

Below are the patches I had to create. All of them, I think, are generally useful:

 * Consistently use `<sys/wait.h>` instead of relying on the Linux-only `<wait.h>` shim
 * Provide the local `clearenv()` implementation for systems other than Linux
 * Use `eaccess()` instead of the Linux-only alias `euidaccess()`
 * The `pEvt->name` can not be a `NULL` -- fix the tautological compare warning from clang
 * Do not `#include` the Linux-specific `<argp.h>` -- does not seem like it is actually needed
 * Other minor header-file fixes necessary on FreeBSD and a good idea everywhere