### PR TITLE
<stdlib.h> is required for daemon(3).

### DIFF
--- a/icd-main.cpp
+++ b/icd-main.cpp
@@ -23,6 +23,7 @@
 #include <fcntl.h>
 #include <pwd.h>
 #include <dirent.h>
+#include <stdlib.h>
 #include <syslog.h>
 #include <errno.h>
 #include <unistd.h>


### PR DESCRIPTION
Do not rely `<stdlib.h>` being included implicitly.