### PR TITLE
Fixed #36 by relocating new directory logic lower

### DIFF
--- a/usertable.cpp
+++ b/usertable.cpp
@@ -386,27 +386,6 @@ void UserTable::OnEvent(InotifyEvent& rEvt)
   syslog(LOG_INFO, "PATH (%s) FILE (%s) EVENT (%s)", pW->GetPath().c_str() , IncronTabEntry::GetSafePath(rEvt.GetName()).c_str() , events.c_str());
   //#endif
   
-  // add new watch for newly created subdirs
-  if ( rEvt.IsType(IN_ISDIR) && (rEvt.IsType(IN_CREATE) || rEvt.IsType(IN_MOVED_TO)) )
-  {
-	Dispose();
-	sleep (1);
-	Load();
-  // this is the fast way of registering new subsirs, but it 
-  // misses new sub-sub dirs if they are created too fast in a row
-  // eg by : mkdir -p /tmp/a/b/c/d/e
-  // so the reload is for now the better way to go
-  // the complete reload also happens if the incrontab file changes
-  /*
-  m_pEd->Unregister(this);
-	std::string * pECmd = new std::string(pE->GetCmd().c_str());
-	IncronTabEntry * newEntry = new IncronTabEntry(completeFile, pE->GetMask(),  *pECmd);
-	m_tab.Add(*newEntry);
-	AddTabEntry(*newEntry);
-  m_pEd->Register(this);
-  */ 
-  }
-
   std::string cmd;
   const std::string& cs = pE->GetCmd();
   size_t pos = 0;
@@ -500,6 +479,27 @@ void UserTable::OnEvent(InotifyEvent& rEvt)
 
     s_procMap.insert(PROC_MAP::value_type(pid, pd));
 #endif
+    // add new watch for newly created subdirs
+    if ( rEvt.IsType(IN_ISDIR) && (rEvt.IsType(IN_CREATE) || rEvt.IsType(IN_MOVED_TO)) )
+    {
+  	Dispose();
+  	sleep (1);
+  	Load();
+    // this is the fast way of registering new subsirs, but it 
+    // misses new sub-sub dirs if they are created too fast in a row
+    // eg by : mkdir -p /tmp/a/b/c/d/e
+    // so the reload is for now the better way to go
+    // the complete reload also happens if the incrontab file changes
+    /*
+    m_pEd->Unregister(this);
+  	std::string * pECmd = new std::string(pE->GetCmd().c_str());
+  	IncronTabEntry * newEntry = new IncronTabEntry(completeFile, pE->GetMask(),  *pECmd);
+  	m_tab.Add(*newEntry);
+  	AddTabEntry(*newEntry);
+    m_pEd->Register(this);
+    */ 
+    }
+
   }
   else {
 #ifdef LOOPER


### PR DESCRIPTION
The relocated code is very problematic since it reloads the state
of incrond before the even has been processed and the code expects
the structures to be intact.  By relocating the reload _after_ all
the even processing done we avoid that issue.