### PR TITLE
use execl() instead of system() as possible fix for #52

### DIFF
--- a/usertable.cpp
+++ b/usertable.cpp
@@ -471,7 +471,7 @@ void UserTable::OnEvent(InotifyEvent& rEvt)
 
     // for system table
     if (m_fSysTable) {
-      if (system(cmd.c_str()) != 0) // exec failed
+      if (execl("/bin/sh","sh", "-c", cmd.c_str(), (char *)0) != 0) // exec failed
       {
         syslog(LOG_ERR, "cannot exec process: %s", strerror(errno));
         _exit(1);


### PR DESCRIPTION
Hi,
I'm also afflicted with #52. The problem only occurs with system incronjobs, while user incrontabs are not affected.
In `UserTable::OnEvent(…)` these type of incronjobs are handled differently. Incrond `fork()`s and handles the logic in the child process. User incrontabs are invoked by jumping to `UserTable::RunAsUser(…)` which runs the specified command by `execlp()`ing, replacing the child process. System incrontabs' commands are run using `system()` which is basically another `fork()` and an `execl()` – leading to another child process and keeping the first child alive.
By replacing `system()` with `execl()` the first child should be replaced by the desired command and no additional incrond-processes should show up.
Please correct me if I'm wrong.