### PR TITLE
usertable: change system to execl call

### DIFF
--- a/usertable.cpp
+++ b/usertable.cpp
@@ -471,11 +471,9 @@ void UserTable::OnEvent(InotifyEvent& rEvt)
 
     // for system table
     if (m_fSysTable) {
-      if (system(cmd.c_str()) != 0) // exec failed
-      {
-        syslog(LOG_ERR, "cannot exec process: %s", strerror(errno));
-        _exit(1);
-      }
+      execl("/bin/sh", "sh", "-c", cmd.c_str(), (char *) NULL);
+      syslog(LOG_ERR, "cannot exec process: %s", strerror(errno));
+      _exit(1);
     }
     else {
       // for user table


### PR DESCRIPTION
The man page for system states clear - execl is called AFTER fork,
usertable for root is calling system after fork so we have fork, fork
which is clearly not is expected couse the forked proccess doesn't exit.

This result into many instances of incrond which state is uknown.

Let's just call execl("/bin/sh", "sh", "-c", command, (char *) NULL); as
per manual as we have forked before this call.