### PR TITLE
Replace system() with execl() to remove extra forking

### DIFF
--- a/usertable.cpp
+++ b/usertable.cpp
@@ -471,11 +471,10 @@ void UserTable::OnEvent(InotifyEvent& rEvt)
 
     // for system table
     if (m_fSysTable) {
-      if (system(cmd.c_str()) != 0) // exec failed
-      {
-        syslog(LOG_ERR, "cannot exec process: %s", strerror(errno));
-        _exit(1);
-      }
+       execl("/bin/sh", "sh", "-c", cmd.c_str(), (char *) 0);
+       int rc = errno;
+       syslog(LOG_ERR, "cannot exec process: %s", strerror(rc));
+       _exit(1);
     }
     else {
       // for user table


### PR DESCRIPTION
The behaviour of forking and then calling system()
results in a fork-of-a-fork and is unaccounted for.
This causes extra incrond processes to pile up.
Replaced system() with its equivalent exec, sans
fork.