### PR TITLE
Fix IncronTabEntry::GetSafePath

### DIFF
--- a/incrontab.cpp
+++ b/incrontab.cpp
@@ -165,20 +165,17 @@ bool IncronTabEntry::Parse(const std::string& rStr, IncronTabEntry& rEntry)
 std::string IncronTabEntry::GetSafePath(const std::string& rPath)
 {
   std::ostringstream stream;
-  
+
   SIZE len = rPath.length();
   for (SIZE i = 0; i < len; i++) {
-    if (rPath[i] == ' ') {
-      stream << "\\ ";
-    }
-    else if (rPath[i] == '\\') {
-      stream << "\\\\";
+    if (rPath[i] == '\'') {
+      stream << "'\\''"; // close single quote, place escaped one, open another single quote
     }
     else {
       stream << rPath[i];
     }
   }
-  
+
   return stream.str();
 }
 


### PR DESCRIPTION
Previously only the space character (why?) and the backslash character were escaped, leaving commands vulnerable to shell injection.

The correct way is to only escape the single-quote, and then put the path variables '$@' '$#' in them in commands. Other characters need not be escaped, as they will not be treated as special within single-quoted strings.

This fixes multiple vulnerabilities.
